### PR TITLE
add git workspace

### DIFF
--- a/tmpl_cf.sh
+++ b/tmpl_cf.sh
@@ -12,6 +12,9 @@ pr_body=$(echo "$config" | jq -r '.pr_body')
 
 access_token="${ACCESS_TOKEN}"
 
+# Add an exception for the GitHub Actions workspace
+git config --global --add safe.directory /github/workspace
+
 # Create a new branch
 # TODO: If the blanch exists in a remote repository, you should checkout the one.
 git checkout -b "$follower_branch_name"


### PR DESCRIPTION
I got an error.

```
fatal: detected dubious ownership in repository at '/github/workspace'
To add an exception for this directory, call:

	git config --global --add safe.directory /github/workspace
Cloning into 'template-repo'...
fatal: could not read Username for 'https://github.com/': No such device or address
/usr/bin/tmpl_cf.sh: line 33: cd: template-repo: No such file or directory
fatal: detected dubious ownership in repository at '/github/workspace'
```

To fix above, I added a git config line.